### PR TITLE
Don't needlessly reinstall packages on arch

### DIFF
--- a/lib/knife-solo/bootstraps/linux.rb
+++ b/lib/knife-solo/bootstraps/linux.rb
@@ -32,7 +32,7 @@ module KnifeSolo::Bootstraps
 
     def pacman_install
       ui.msg("Installing required packages...")
-      run_command("sudo pacman -Sy ruby rsync make gcc --noconfirm")
+      run_command("sudo pacman --needed -Sy ruby rsync make gcc --noconfirm")
       run_command("sudo gem install chef --no-user-install --no-rdoc --no-ri")
     end
 


### PR DESCRIPTION
The default behavior of pacman is to reinstall packages if you do `pacman -S <pkg>` and it's already installed.

I added the `--needed` flag to pacman so that it only installs packages if they aren't installed.

[Tested with Arch linux](https://gist.github.com/zfjagann/f1395880b1a00a24a002)
